### PR TITLE
Waveform 12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.flatpak-builder

--- a/apply_extra.sh
+++ b/apply_extra.sh
@@ -6,29 +6,29 @@ FLATPAK_ID=com.tracktion.Waveform
 
 # Unpack the .deb file
 mkdir -p deb-package
-ar p waveform11.deb data.tar.xz | tar -xJf - -C deb-package
+ar p waveform12.deb data.tar.xz | tar -xJf - -C deb-package
 
 # Move to export/share
 mkdir -p export/share
-mv deb-package/usr/bin/Waveform11 waveform11
+mv deb-package/usr/bin/Waveform12 waveform12
 mv deb-package/usr/share/{applications,doc,mime} export/share/
 
 # Icon
 mkdir -p export/share/icons/hicolor/512x512/apps
 mv deb-package/usr/share/pixmaps/* export/share/icons/hicolor/512x512/apps
 
-rename "waveform11" "${FLATPAK_ID}" export/share/{applications,mime/packages,icons/hicolor/*/*}/waveform11.*
+rename "waveform12" "${FLATPAK_ID}" export/share/{applications,mime/packages,icons/hicolor/*/*}/waveform12.*
 
 # Desktop file
 desktop-file-edit \
     --set-key="Exec" --set-value="waveform %U" \
     --set-key="Icon" --set-value="${FLATPAK_ID}" \
     --set-key="Categories" --set-value="AudioVideo;AudioVideoEditing;" \
-    --set-key="X-Flatpak-RenamedFrom" --set-value="waveform11.desktop;" \
+    --set-key="X-Flatpak-RenamedFrom" --set-value="waveform12.desktop;" \
     "export/share/applications/${FLATPAK_ID}.desktop"
 
 # Download manager
 ar p tracktion-download-manager.deb data.tar.xz | tar -xJf - -C deb-package
 mv deb-package/usr/bin/tracktion-download-manager tracktion-download-manager
 
-rm -r waveform11.deb tracktion-download-manager.deb deb-package
+rm -r waveform12.deb tracktion-download-manager.deb deb-package

--- a/com.tracktion.Waveform.appdata.xml
+++ b/com.tracktion.Waveform.appdata.xml
@@ -36,122 +36,51 @@
   </requires>
 
   <screenshots>
+    <screenshot type="default">
+      <caption>Waveform main screen</caption>
+      <image>https://cdn.mos.cms.futurecdn.net/S3RiAQVCqszQ6ZqUipGNPc.jpg</image>
+    </screenshot>
+
     <!-- from https://www.tracktion.com/products/waveform-pro-features -->
-    <screenshot type="default">
-      <caption>Studio photo</caption>
-      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/w12-hero-waveform-desk-window.jpg</image>
-    </screenshot>
-    <screenshot type="default">
-      <caption>Arranger Track</caption>
-      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/features/waveform11pro-feature-arranger-track.jpg</image>
-    </screenshot>
-    <screenshot type="default">
-      <caption>View Presets</caption>
-      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/features/waveform11pro-feature-view-presets-3view-v2_2x.png</image>
-    </screenshot>
-    <screenshot type="default">
+    <screenshot>
       <caption>Quick Action Bar</caption>
       <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/features/waveform11pro-feature-quick-action-window-v2.jpg</image>
     </screenshot>
-    <screenshot type="default">
-      <caption>Custom Layouts</caption>
-      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/features/waveform11pro-feature-short-custom-layout.jpg</image>
-    </screenshot>
-    <screenshot type="default">
-      <caption>Edit Overview</caption>
-      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/features/waveform11pro-feature-short-edit-overview.jpg</image>
-    </screenshot>
-    <screenshot type="default">
-      <caption>Audio Chord Track</caption>
-      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/features/waveform11pro-feature-short-chord-track.jpg</image>
-    </screenshot>
-    <screenshot type="default">
+    <screenshot>
       <caption>New MIDI Tools</caption>
       <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/features/waveform11pro-feature-midi-tools.jpg</image>
     </screenshot>
-    <screenshot type="default">
+    <screenshot>
       <caption>Plugin Sandboxing</caption>
       <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/features/waveform11pro-feature-plugin-sandbox.jpg</image>
     </screenshot>
     <!-- from https://www.tracktion.com/products/waveform-pro-whats-new -->
-    <screenshot type="default">
-      <caption>Fresh UI Makeover</caption>
-      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-back-ui.jpg</image>
-    </screenshot>
-    <screenshot type="default">
-      <caption>Improved Quick Actions</caption>
-      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-front-quickaction.jpg</image>
-    </screenshot>
-    <screenshot type="default">
-      <caption>Entirely New Browser</caption>
-      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-back-browser.jpg</image>
-    </screenshot>
-    <screenshot type="default">
-      <caption>Brand New BassOSC Instrument</caption>
-      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-bassosc-v2.jpg</image>
-    </screenshot>
-    <screenshot type="default">
-      <caption>Dual Guitar IR</caption>
-      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-macbook-guitar-ir-v2.jpg</image>
-    </screenshot>
-    <screenshot type="default">
-      <caption>Utility Plugins</caption>
-      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-unity.jpg</image>
-    </screenshot>
-    <screenshot type="default">
-      <caption>15 Refreshed Audio Effects</caption>
-      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-tall-15fx.jpg</image>
-    </screenshot>
-    <screenshot type="default">
+    <screenshot>
       <caption>Advanced MIDI</caption>
       <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-midi-advanced.jpg</image>
     </screenshot>
-    <screenshot type="default">
-      <caption>MIDI Randomisation</caption>
-      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-back-midi-random.jpg</image>
-    </screenshot>
-    <screenshot type="default">
+    <screenshot>
       <caption>New Drum Grid Mode</caption>
       <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-drum-grid.jpg</image>
     </screenshot>
-    <screenshot type="default">
+    <screenshot>
       <caption>Probability Added to Step Clips</caption>
       <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-step-probability.jpg</image>
     </screenshot>
-    <screenshot type="default">
+    <screenshot>
       <caption>MIDI Strum</caption>
       <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-midi-strum.jpg</image>
     </screenshot>
-    <screenshot type="default">
+    <screenshot>
       <caption>Rewritten Audio Engine</caption>
       <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-audio-engine.jpg</image>
     </screenshot>
-    <screenshot type="default">
-      <caption>Added Controller Support</caption>
-      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-controller-partners.jpg</image>
-    </screenshot>
     <!-- from https://www.tracktion.com/products/waveform-pro-content -->
-    <screenshot type="default">
-      <caption>DAW Essentials Collection</caption>
-      <image>https://www.tracktion.com/sites/default/files/img/products/dawessentials/daw-essentials-hero-light.png</image>
-    </screenshot>
-    <screenshot type="default">
-      <caption>Artisan Collection</caption>
-      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/content/waveform11pro-feature-artisan-collection.jpg</image>
-    </screenshot>
-    <screenshot type="default">
-      <caption>4OSC</caption>
-      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/content/waveform11pro-feature-4osc-v3.jpg</image>
-    </screenshot>
-    <screenshot type="default">
-      <caption>Elastique Pro</caption>
-      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/features/feature-box-elastique.jpg</image>
-    </screenshot>
-    <screenshot type="default">
+    <screenshot>
       <caption>Subtractive</caption>
       <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/features/wpro-feature-subtractive.jpg</image>
     </screenshot>
-    <screenshot type="default">
+    <screenshot>
       <caption>Drum Sampler</caption>
       <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/features/waveform10-feature-drum-sampler-1.jpg</image>
     </screenshot>

--- a/com.tracktion.Waveform.appdata.xml
+++ b/com.tracktion.Waveform.appdata.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
   <id>com.tracktion.Waveform</id>
-  <name>Waveform11</name>
+  <name>Waveform12</name>
   <summary>Digital audio workstation for all music creators</summary>
   <developer_name>Tracktion Software Corporation</developer_name>
-  <icon type="remote">https://www.tracktion.com/wp/wp-content/uploads/2020/03/product-logo-waveform11_3x.png</icon>
+  <icon type="remote">https://www.tracktion.com/sites/default/files/img/products/waveform-free/logo-waveform-free2021.png</icon>
   <url type="homepage">https://www.tracktion.com/</url>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>LicenseRef-proprietary=https://marketplace.tracktion.com/terms-of-use</project_license>
@@ -36,51 +36,127 @@
   </requires>
 
   <screenshots>
+    <!-- from https://www.tracktion.com/products/waveform-pro-features -->
     <screenshot type="default">
-      <caption>Modular mix screen</caption>
-      <image>https://www.tracktion.com/wp/wp-content/uploads/2017/03/waveform-screen-modular-mix.jpg</image>
+      <caption>Studio photo</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/w12-hero-waveform-desk-window.jpg</image>
     </screenshot>
     <screenshot type="default">
-      <caption>Collective</caption>
-      <image>https://www.tracktion.com/wp/wp-content/uploads/2017/03/waveform-screen-collective-hd.jpg</image>
+      <caption>Arranger Track</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/features/waveform11pro-feature-arranger-track.jpg</image>
     </screenshot>
     <screenshot type="default">
-      <caption>Unlimited tracks</caption>
-      <image>https://www.tracktion.com/wp/wp-content/uploads/2017/03/waveform-screen-unlimited.jpg</image>
+      <caption>View Presets</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/features/waveform11pro-feature-view-presets-3view-v2_2x.png</image>
     </screenshot>
     <screenshot type="default">
-      <caption>Composition tools</caption>
-      <image>https://www.tracktion.com/wp/wp-content/uploads/2017/03/waveform-screen-composition-tools.jpg</image>
+      <caption>Quick Action Bar</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/features/waveform11pro-feature-quick-action-window-v2.jpg</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Custom Layouts</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/features/waveform11pro-feature-short-custom-layout.jpg</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Edit Overview</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/features/waveform11pro-feature-short-edit-overview.jpg</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Audio Chord Track</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/features/waveform11pro-feature-short-chord-track.jpg</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>New MIDI Tools</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/features/waveform11pro-feature-midi-tools.jpg</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Plugin Sandboxing</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/features/waveform11pro-feature-plugin-sandbox.jpg</image>
+    </screenshot>
+    <!-- from https://www.tracktion.com/products/waveform-pro-whats-new -->
+    <screenshot type="default">
+      <caption>Fresh UI Makeover</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-back-ui.jpg</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Improved Quick Actions</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-front-quickaction.jpg</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Entirely New Browser</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-back-browser.jpg</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Brand New BassOSC Instrument</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-bassosc-v2.jpg</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Dual Guitar IR</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-macbook-guitar-ir-v2.jpg</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Utility Plugins</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-unity.jpg</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>15 Refreshed Audio Effects</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-tall-15fx.jpg</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Advanced MIDI</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-midi-advanced.jpg</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>MIDI Randomisation</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-back-midi-random.jpg</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>New Drum Grid Mode</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-drum-grid.jpg</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Probability Added to Step Clips</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-step-probability.jpg</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>MIDI Strum</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-midi-strum.jpg</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Rewritten Audio Engine</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-audio-engine.jpg</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Added Controller Support</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro12/new/w12-feature-controller-partners.jpg</image>
+    </screenshot>
+    <!-- from https://www.tracktion.com/products/waveform-pro-content -->
+    <screenshot type="default">
+      <caption>DAW Essentials Collection</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/dawessentials/daw-essentials-hero-light.png</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Artisan Collection</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/content/waveform11pro-feature-artisan-collection.jpg</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>4OSC</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/content/waveform11pro-feature-4osc-v3.jpg</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Elastique Pro</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/features/feature-box-elastique.jpg</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Subtractive</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/features/wpro-feature-subtractive.jpg</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Drum Sampler</caption>
+      <image>https://www.tracktion.com/sites/default/files/img/products/waveform-pro11/features/waveform10-feature-drum-sampler-1.jpg</image>
     </screenshot>
   </screenshots>
 
   <content_rating type="oars-1.1" />
-
-  <releases>
-    <release date="2021-07-15" version="11.5.18">
-      <description>
-        <ul>
-          <li>UI: When resizing clips, edit cursor snaps to end of clip</li>
-          <li>Linux: Sort font names in menu</li>
-          <li>Windows: Fixed keyboard shortcuts not working when MIDI Typing enabled</li>
-          <li>UI: Added Live Input Monitoring to track input context menu</li>
-          <li>UI: Fixed groove strength covering transpose button</li>
-          <li>UI: Fixed moving controller data</li>
-          <li>Windows: Fixed MP3 playback in browser</li>
-          <li>Windows: Fixed pitch shifting of clips with MP3 source files</li>
-          <li>Plugins: Fixed loading some Softube plugins on macOS</li>
-          <li>Plugins: Fixed an issue where iZotope plugin windows couldn't be dragged</li>
-        </ul>
-      </description>
-    </release>
-
-    <release date="2021-05-20" version="11.5.17">
-      <description>
-        <ul>
-          <li>Plugins: Fixed crash loading jbridge plugins</li>
-        </ul>
-      </description>
-    </release>
-  </releases>
 
 </component>

--- a/com.tracktion.Waveform.yml
+++ b/com.tracktion.Waveform.yml
@@ -105,16 +105,17 @@ modules:
       - install -Dm644 com.tracktion.Waveform.appdata.xml /app/share/appdata/com.tracktion.Waveform.appdata.xml
       - install -Dm755 apply_extra.sh /app/bin/apply_extra
       - install -Dm755 waveform.sh /app/bin/waveform
+      - install -Dm755 download-manager.sh /app/bin/tracktion-download-manager
     post-install:
       - install -d /app/extensions/Plugins
     sources:
       - type: extra-data
-        filename: waveform11.deb
+        filename: waveform12.deb
         only-arches:
           - x86_64
-        url: https://cdn.tracktion.com/file/tracktiondownload/waveform/11518/waveform_64bit_v11.5.18.deb
-        sha256: 911aa08887e0a6690f3b002e4aec618bf1f5f1ece089c468fb06d359e15ac1e5
-        size: 56707814
+        url: https://cdn.tracktion.com/file/tracktiondownload/w12/12053/waveform_64bit_v12.0.53.deb
+        sha256: ef33fe0b8626587be667cc0e1bf64dcffe56c868705112cae33d39d4893e9f63
+        size: 104772954
 
       - type: extra-data
         filename: tracktion-download-manager.deb
@@ -130,7 +131,12 @@ modules:
       - type: script
         dest-filename: waveform.sh
         commands:
-          - exec /app/extra/waveform11 $@
+          - exec /app/extra/waveform12 "$@"
+
+      - type: script
+        dest-filename: download-manager.sh
+        commands:
+          - exec /app/extra/tracktion-download-manager "$@"
 
       - type: file
         path: com.tracktion.Waveform.appdata.xml


### PR DESCRIPTION
This updates Waveform package to Waveform 12. I also took a liberty of updating screenshots, since all current screenshot urls return 404. I couldn't find changelog/release notes for Waveform 12, so I removed the releases section.